### PR TITLE
callback_id is a string

### DIFF
--- a/tamtam/types/updates.py
+++ b/tamtam/types/updates.py
@@ -136,7 +136,7 @@ class Callback(BaseModel):
     timestamp: int
     """unix-time when event occurred"""
 
-    callback_id: int
+    callback_id: str
     """current keyboard identifier"""
 
     payload: str = None


### PR DESCRIPTION
`callback_id` is a string, not a number by documentation